### PR TITLE
Adding initial set contract for majority set contract

### DIFF
--- a/contracts/InitialSet.sol
+++ b/contracts/InitialSet.sol
@@ -1,0 +1,23 @@
+//! Copyright 2018 C4Coin
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//!     http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+
+pragma solidity ^0.4.23;
+
+
+contract InitialSet {
+  // Pending list of validator addresses.
+  address[] pendingList = [
+    0x00f5777f8133aae2734396ab1d43ca54ad11bfb737
+  ];
+}

--- a/contracts/MajoritySet.sol
+++ b/contracts/MajoritySet.sol
@@ -18,6 +18,7 @@ pragma solidity ^0.4.23;
 
 import "./interfaces/ValidatorSet.sol";
 import "./libraries/AddressVotes.sol";
+import "./InitialSet.sol";
 
 // Existing validators can give support to addresses.
 // Support can not be added once MAX_VALIDATORS are present.
@@ -28,7 +29,7 @@ import "./libraries/AddressVotes.sol";
 // Benign misbehaviour can be absolved before being called the second time.
 
 
-contract MajoritySet is ValidatorSet {
+contract MajoritySet is ValidatorSet, InitialSet {
     // EVENTS
     event Report(address indexed reporter, address indexed reported, bool indexed malicious);
     event Support(address indexed supporter, address indexed supported, bool indexed added);
@@ -62,8 +63,6 @@ contract MajoritySet is ValidatorSet {
 
     // Current list of addresses entitled to participate in the consensus.
     address[] public validatorsList;
-    // Pending list of validator addresses.
-    address[] pendingList;
     // Was the last validator change finalized.
     bool finalized;
     // Tracker of status for each address.


### PR DESCRIPTION
The pending list that gets populated beforehand needs to be pulled from a separate contract.  For our build automation the InitialSet contract will be generated and overwrite the one here likely using a CLI program that does templating through mustache or perhaps hygen. 